### PR TITLE
Animate instantly when the user prefers reduced motion

### DIFF
--- a/PLUGH.js
+++ b/PLUGH.js
@@ -335,7 +335,8 @@ if(typeof process != "undefined" && typeof require != "undefined") { exports.plu
 
 		
 		let cgeneration = document.querySelector('[data-generation="'+this.generation+'"]');
-		this.consoleOutput.scrollTo({top: cgeneration&&!forceBottom?cgeneration.offsetTop:this.consoleOutput.scrollHeight,behavior:'smooth'});
+		let scrollBehavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth';
+		this.consoleOutput.scrollTo({top: cgeneration&&!forceBottom?cgeneration.offsetTop:this.consoleOutput.scrollHeight,behavior:scrollBehavior});
 	}
 	
 	this.pressEnter = function() {

--- a/src/CommandLine.js
+++ b/src/CommandLine.js
@@ -142,7 +142,8 @@ function CommandLine() {
 
 		
 		let cgeneration = document.querySelector('[data-generation="'+this.generation+'"]');
-		this.consoleOutput.scrollTo({top: cgeneration&&!forceBottom?cgeneration.offsetTop:this.consoleOutput.scrollHeight,behavior:'smooth'});
+		let scrollBehavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth';
+		this.consoleOutput.scrollTo({top: cgeneration&&!forceBottom?cgeneration.offsetTop:this.consoleOutput.scrollHeight,behavior:scrollBehavior});
 	}
 	
 	this.pressEnter = function() {


### PR DESCRIPTION
The [`prefers-reduced-motion` media query](https://css-tricks.com/introduction-reduced-motion-media-query/) allows users to specify an accessibility setting for less animation. Smooth scrolling in particular often triggers seasickness.

This pull request disables smooth scrolling when the user prefers reduced motion.